### PR TITLE
Added file format and scale options

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -188,7 +188,7 @@ function getImages (icons) {
   return new Promise((resolve) => {
     spinner.start('Fetching icon urls')
     const iconIds = icons.map(icon => icon.id).join(',')
-    figmaClient.get(`/images/${config.fileId}?ids=${iconIds}&format=svg`)
+    figmaClient.get(`/images/${config.fileId}?ids=${iconIds}&format=${config.format}&scale=${config.scale}`)
       .then((res) => {
         spinner.succeed()
         const images = res.data.images
@@ -221,7 +221,8 @@ function downloadImage (url, name) {
       }
     }
   }
-  const imagePath = path.resolve(directory, `${nameClean}.svg`)
+  let suffix = config.scale == 1 ? '' : `@${config.scale}x`
+  const imagePath = path.resolve(directory, `${nameClean}${suffix}.${config.format}`)
   const writer = fs.createWriteStream(imagePath)
 
 
@@ -240,9 +241,9 @@ function downloadImage (url, name) {
 
   return new Promise((resolve, reject) => {
     writer.on('finish', () => {
-      // console.log(`Saved ${name}.svg`, fs.statSync(imagePath).size)
+      // console.log(`Saved ${name}.${config.format}`, fs.statSync(imagePath).size)
       resolve({
-        name: `${name}.svg`,
+        name: `${name}.${config.format}`,
         size: fs.statSync(imagePath).size
       })
     })

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -3,7 +3,9 @@ const defaults = {
   page: 'Identity',
   frame: 'Icons',
   iconsPath: 'assets/svg/icons',
-  removeFromName: 'Icon='
+  removeFromName: 'Icon=',
+  format: "svg",
+  scale: 1
 }
 
 module.exports = defaults

--- a/src/prompts.js
+++ b/src/prompts.js
@@ -16,7 +16,7 @@ const prompts = [
   {
     type: 'text',
     name: 'page',
-    message: 'Name of the page with icons?',
+    message: 'Name of the page with icons',
     initial: defaults.page
   },
   {
@@ -29,6 +29,18 @@ const prompts = [
     type: 'text',
     name: 'iconsPath',
     message: 'Directory to download the icons to',
+    initial: defaults.iconsPath
+  },
+  {
+    type: 'text',
+    name: 'format',
+    message: 'Icons format for export',
+    initial: defaults.iconsPath
+  },
+  {
+    type: 'text',
+    name: 'scale',
+    message: 'Icons scale (default 1)',
     initial: defaults.iconsPath
   }
 ]


### PR DESCRIPTION
Hers is PR added file format and scale options.

1. Format
Able to export icons in PNG also, not only SVG. SVG is default, nothing must be broken in format is not set.

2. Scale
Scale usually is needed for bitmap formats (e.g. PNG), so it's made in this PR also. Suffix @2x (quite common) is used for scaled icons, not suffix for 1x icons.