### PR TITLE
adding variant support

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -178,9 +178,18 @@ function getFigmaFile () {
           }
           iconsArray = frameRoot.children.find(c => c.name === frameName).children
         }
-        let icons = iconsArray.map((icon) => {
-          return { id: icon.id, name: icon.name }
-        })
+        let icons = iconsArray.flatMap((icon) => {
+          if ( config.exportVariants &&  icon.children && icon.children.length > 0 ) {
+            return icon.children.map((child) => {
+              const variants = child.name.split(',').map((prop, index) => {
+                return prop.trim().replace('=', '-').toLowerCase();
+              }).join('--');
+              return { id: child.id, name: icon.name + '__' + variants }
+            });
+          } else {
+            return [{ id: icon.id, name: icon.name }]
+          }
+        });
         icons = findDuplicates('name', icons)
         resolve(icons)
       })

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -3,7 +3,8 @@ const defaults = {
   page: 'Identity',
   frame: 'Icons',
   iconsPath: 'assets/svg/icons',
-  removeFromName: 'Icon='
+  removeFromName: 'Icon=',
+  exportVariants: false
 }
 
 module.exports = defaults

--- a/src/prompts.js
+++ b/src/prompts.js
@@ -30,6 +30,14 @@ const prompts = [
     name: 'iconsPath',
     message: 'Directory to download the icons to',
     initial: defaults.iconsPath
+  },
+  {
+    type: 'toggle',
+    name: 'exportVariants',
+    message: 'Export variants as individual icons',
+    initial: defaults.exportVariants,
+    active: 'yes',
+    inactive: 'no'
   }
 ]
 


### PR DESCRIPTION
Figma has the notion of variants or grouped nodes.  

This 2x2 grid has 2 different variations creating 4 possible outcomes.
![Screen Shot 2022-01-24 at 11 54 47 AM](https://user-images.githubusercontent.com/2066227/150855984-983b81a4-cab6-47c3-9173-19a0b15790f5.png)

We've begun using these to group icon variations within our Figma component library.  They follow a certain Figma naming convention like so:
![Screen Shot 2022-01-24 at 11 54 57 AM](https://user-images.githubusercontent.com/2066227/150856100-5fe18096-a07f-403a-bdd3-b1d7d98eda03.png)

This allows a designer in Figma to grab this component and see that possible variations that can be set:
![Screen Shot 2022-01-24 at 11 55 43 AM](https://user-images.githubusercontent.com/2066227/150856247-0e08974b-d9a8-4f9a-be5c-00a2c1391df5.png)

This script doesn't currently support exporting these variations as icons.  Currently this will just export the first icon in the grouped variation set but we needed it to export each individual icon as a separate icon.   Within the returned API data they appear as children node under what is currently considered the `icon`.  

I've added a flag to the config whether variations should be exported (defaulted to false) so that won't break any current implementations.   The name for the exported icon has been modified to follow the pattern `<variant_icon_name>__<variant_property>-<variant_value>(--<variant_property>-<variant_value> repeated for all properties present).svg`