### PR TITLE
adding maxConcurrentConnections

### DIFF
--- a/src/defaults.js
+++ b/src/defaults.js
@@ -3,7 +3,8 @@ const defaults = {
   page: 'Identity',
   frame: 'Icons',
   iconsPath: 'assets/svg/icons',
-  removeFromName: 'Icon='
+  removeFromName: 'Icon=',
+  maxConcurrentConnections: 500
 }
 
 module.exports = defaults

--- a/src/prompts.js
+++ b/src/prompts.js
@@ -30,6 +30,14 @@ const prompts = [
     name: 'iconsPath',
     message: 'Directory to download the icons to',
     initial: defaults.iconsPath
+  },
+  {
+    type: 'number',
+    name: 'maxConcurrentConnections',
+    message: 'Maximum amount of concurrent S3 connections',
+    initial: defaults.maxConcurrentConnections,
+    min: 1,
+    max: 1000
   }
 ]
 


### PR DESCRIPTION
I was seeing issues related to how many icons were being requested at a time.  Without any sort of throttle and above ~225 icons I was getting errors from S3 `ECONNRESET` and the failing icon always being different when running the script.  The script also logged the icon's S3 URL that was part of the error and it would load fine in the browser.

I played around with how many icons were requested and for me once I got it below 225 it worked without error.  So I went ahead and added a `maxConcurrentConnections` to solve this issue.

It will chunk the icons found and then sends those through in batches.  It won't move onto the next chunk until the current one has completed.

This may also fix #13 

